### PR TITLE
readme.md Spelling correction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# acode-plugin-perttier
+# acode-plugin-prettier
 
 Prettier is an opinionated code formatter. It enforces a consistent style by parsing your code and re-printing it with its own rules that take the maximum line length into account, wrapping code when necessary.
 


### PR DESCRIPTION
"acode-plugin-perttier" --> "acode-plugin-prettier"